### PR TITLE
Make object serializer work with wp_options

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1339,5 +1339,14 @@ class icit_srdb {
  * @return void
  */
 function object_serializer( $class_name ) {
-    eval( "class {$class_name} extends ArrayObject {}" );
+
+   $prefix = '';
+
+   if (($pos = strrpos($class_name, "\\")) !== false) {
+       $namespace = substr($class_name, 0, $pos);
+       $class_name = substr($class_name, $pos + 1);
+       $prefix = "namespace  {$namespace};";
+   }
+
+   eval( "{$prefix} class {$class_name} extends \ArrayObject {}" );
 }


### PR DESCRIPTION
Fixing syntax error, unexpected '\' (T_NS_SEPARATOR), expecting '{' which makes SnR fail when rewriting wp_options. 